### PR TITLE
#61 Adicionando documentos de estágio que o bot envia

### DIFF
--- a/bot/actions/actions.py
+++ b/bot/actions/actions.py
@@ -60,17 +60,6 @@ class ActionEnviarModeloDeTermoRescisorio(Action):
 		url = 'https://fga.unb.br/articles/0002/2351/termo_de_rescisorio.pdf'
 		bot.sendDocument(chat_id=tracker.sender_id, document = url)
 
-class ActionEnviarModeloDeRelatorio(Action):
-	def name(self):
-		return "action_enviar_relatorio_atividades"
-
-	def run(self, dispatcher, tracker, domain):
-		dispatcher.utter_message("Eu tenho o modelo de relatório de atividades para te enviar!")
-		dispatcher.utter_message("Estou te enviando agora.")
-		bot = telegram.Bot(token='TELEGRAM_TOKEN')
-		url = 'https://drive.google.com/file/d/1qomiocsmBqUJ0dd2_377oxUHdeYyGCMf/view'
-		bot.sendDocument(chat_id=tracker.sender_id, document = url)
-
 class ActionTodosOsCoordenadores(Action):
 	def name(self):
 		return "action_todos_os_coordenadores"

--- a/bot/actions/actions.py
+++ b/bot/actions/actions.py
@@ -10,9 +10,7 @@ class ActionEnviarDocFaqEstagio(Action):
 		dispatcher.utter_message("Eu tenho muitas informações sobre estágio para você, Vossa Majestade!")
 		dispatcher.utter_message("Estou te enviando um documento com as dúvidas mais pertinentes que os alunos costumam ter")
 		bot = telegram.Bot(token='TELEGRAM_TOKEN')
-		url = 'https://fga.unb.br/articles/0002/2354/tce_para_estagio_obrigatorio.pdf'
-		bot.sendDocument(chat_id=tracker.sender_id,document=url)
-		url = 'https://fga.unb.br/articles/0002/2356/tce_para_estagio_nao_obrigatorio.pdf'
+		url = 'https://aprender.ead.unb.br/pluginfile.php/688847/mod_resource/content/5/faq_estagio_supervisionado.pdf'
 		bot.sendDocument(chat_id=tracker.sender_id,document=url)
 
 class ActionEnviarTCEPA(Action):
@@ -23,7 +21,9 @@ class ActionEnviarTCEPA(Action):
 		dispatcher.utter_message("Eu tenho esses documentos de estágio supervisionado e não-obrigatório!")
 		dispatcher.utter_message("Estou te enviando o TCE e o PA")
 		bot = telegram.Bot(token='TELEGRAM_TOKEN')
-		url = 'https://aprender.ead.unb.br/pluginfile.php/688847/mod_resource/content/5/faq_estagio_supervisionado.pdf'
+		url = 'https://fga.unb.br/articles/0002/2354/tce_para_estagio_obrigatorio.pdf'
+		bot.sendDocument(chat_id=tracker.sender_id,document=url)
+		url = 'https://fga.unb.br/articles/0002/2356/tce_para_estagio_nao_obrigatorio.pdf'
 		bot.sendDocument(chat_id=tracker.sender_id,document=url)
 
 class ActionEnviarFichaSolicitacao(Action):
@@ -35,7 +35,7 @@ class ActionEnviarFichaSolicitacao(Action):
 		dispatcher.utter_message("Se você já estiver cadastrado na matéria, pode acessar uma ficha de preenchimento automático pelo moodle.")
 		dispatcher.utter_message("Estou te enviando a Ficha de Solicitação de Matrícula.")
 		bot = telegram.Bot(token='TELEGRAM_TOKEN')
-		url = 'https://aprender.ead.unb.br/pluginfile.php/688847/mod_resource/content/5/faq_estagio_supervisionado.pdf'
+		url = 'https://aprender.ead.unb.br/pluginfile.php/610764/mod_resource/content/2/Anexo1_Ficha_Matr%C3%ADcula_Est%C3%A1gio_Supervisionado_FGA.pdf'
 		bot.sendDocument(chat_id=tracker.sender_id,document=url)
 
 class ActionEnviarModeloDeTermoAditivo(Action):
@@ -68,7 +68,7 @@ class ActionEnviarModeloDeRelatorio(Action):
 		dispatcher.utter_message("Eu tenho o modelo de relatório de atividades para te enviar!")
 		dispatcher.utter_message("Estou te enviando agora.")
 		bot = telegram.Bot(token='TELEGRAM_TOKEN')
-		url = 'https://fga.unb.br/estagio/documentos/documentos-do-daia/relatorio-de-atividades-de-estagio.xlsx'
+		url = 'https://drive.google.com/file/d/1qomiocsmBqUJ0dd2_377oxUHdeYyGCMf/view'
 		bot.sendDocument(chat_id=tracker.sender_id, document = url)
 
 class ActionTodosOsCoordenadores(Action):

--- a/bot/actions/actions.py
+++ b/bot/actions/actions.py
@@ -49,6 +49,17 @@ class ActionEnviarModeloDeTermoAditivo(Action):
 		url = 'https://fga.unb.br/articles/0002/2352/termo_aditivo_ao_tce.pdf'
 		bot.sendDocument(chat_id=tracker.sender_id, document = url)
 
+class ActionEnviarModeloDeTermoAditivo(Action):
+	def name(self):
+		return "action_enviar_termo_rescisorio"
+
+	def run(self, dispatcher, tracker, domain):
+		dispatcher.utter_message("Eu tenho o modelo de termo rescisório para te enviar!")
+		dispatcher.utter_message("Estou te enviando agora.")
+		bot = telegram.Bot(token='TELEGRAM_TOKEN')
+		url = 'https://fga.unb.br/articles/0002/2351/termo_de_rescisorio.pdf'
+		bot.sendDocument(chat_id=tracker.sender_id, document = url)
+
 class ActionTodosOsCoordenadores(Action):
 	def name(self):
 		return "action_todos_os_coordenadores"

--- a/bot/actions/actions.py
+++ b/bot/actions/actions.py
@@ -49,7 +49,7 @@ class ActionEnviarModeloDeTermoAditivo(Action):
 		url = 'https://fga.unb.br/articles/0002/2352/termo_aditivo_ao_tce.pdf'
 		bot.sendDocument(chat_id=tracker.sender_id, document = url)
 
-class ActionEnviarModeloDeTermoAditivo(Action):
+class ActionEnviarModeloDeTermoRescisorio(Action):
 	def name(self):
 		return "action_enviar_termo_rescisorio"
 
@@ -58,6 +58,17 @@ class ActionEnviarModeloDeTermoAditivo(Action):
 		dispatcher.utter_message("Estou te enviando agora.")
 		bot = telegram.Bot(token='TELEGRAM_TOKEN')
 		url = 'https://fga.unb.br/articles/0002/2351/termo_de_rescisorio.pdf'
+		bot.sendDocument(chat_id=tracker.sender_id, document = url)
+
+class ActionEnviarModeloDeRelatorio(Action):
+	def name(self):
+		return "action_enviar_relatorio_atividades"
+
+	def run(self, dispatcher, tracker, domain):
+		dispatcher.utter_message("Eu tenho o modelo de relatório de atividades para te enviar!")
+		dispatcher.utter_message("Estou te enviando agora.")
+		bot = telegram.Bot(token='TELEGRAM_TOKEN')
+		url = 'https://fga.unb.br/estagio/documentos/documentos-do-daia/relatorio-de-atividades-de-estagio.xlsx'
 		bot.sendDocument(chat_id=tracker.sender_id, document = url)
 
 class ActionTodosOsCoordenadores(Action):

--- a/bot/actions/actions.py
+++ b/bot/actions/actions.py
@@ -38,6 +38,17 @@ class ActionEnviarFichaSolicitacao(Action):
 		url = 'https://aprender.ead.unb.br/pluginfile.php/688847/mod_resource/content/5/faq_estagio_supervisionado.pdf'
 		bot.sendDocument(chat_id=tracker.sender_id,document=url)
 
+class ActionEnviarModeloDeTermoAditivo(Action):
+	def name(self):
+		return "action_enviar_modelo_de_termo_aditivo"
+
+	def run(self, dispatcher, tracker, domain):
+		dispatcher.utter_message("Eu tenho o modelo de termo aditivo para te enviar!")
+		dispatcher.utter_message("Estou te enviando agora.")
+		bot = telegram.Bot(token='TELEGRAM_TOKEN')
+		url = 'https://fga.unb.br/articles/0002/2352/termo_aditivo_ao_tce.pdf'
+		bot.sendDocument(chat_id=tracker.sender_id, document = url)
+
 class ActionTodosOsCoordenadores(Action):
 	def name(self):
 		return "action_todos_os_coordenadores"

--- a/bot/actions/actions.py
+++ b/bot/actions/actions.py
@@ -13,7 +13,7 @@ class ActionEnviarDocFaqEstagio(Action):
 		url = 'https://fga.unb.br/articles/0002/2354/tce_para_estagio_obrigatorio.pdf'
 		bot.sendDocument(chat_id=tracker.sender_id,document=url)
 
-class ActionEnviarDocFaqEstagio(Action):
+class ActionEnviarTCEPA(Action):
 	def name(self):
 		return "action_enviar_tce_pa"
 
@@ -21,6 +21,18 @@ class ActionEnviarDocFaqEstagio(Action):
 		dispatcher.utter_message("Eu tenho esses documentos de estágio supervisionado!")
 		dispatcher.utter_message("Caso Vossa Majestade queira esses documentos para estágio não-obrigatório, especifique.")
 		dispatcher.utter_message("Estou te enviando o TCE e o PA")
+		bot = telegram.Bot(token='TELEGRAM_TOKEN')
+		url = 'https://aprender.ead.unb.br/pluginfile.php/688847/mod_resource/content/5/faq_estagio_supervisionado.pdf'
+		bot.sendDocument(chat_id=tracker.sender_id,document=url)
+
+class ActionEnviarFichaSolicitacao(Action):
+	def name(self):
+		return "action_enviar_ficha_solicitacao"
+
+	def run(self, dispatcher, tracker, domain):
+		dispatcher.utter_message("Eu tenho a ficha de solicitação de matrícula em estágio supervisionado!")
+		dispatcher.utter_message("Se você já estiver cadastrado na matéria, pode acessar uma ficha de preenchimento automático pelo moodle.")
+		dispatcher.utter_message("Estou te enviando a Ficha de Solicitação de Matrícula.")
 		bot = telegram.Bot(token='TELEGRAM_TOKEN')
 		url = 'https://aprender.ead.unb.br/pluginfile.php/688847/mod_resource/content/5/faq_estagio_supervisionado.pdf'
 		bot.sendDocument(chat_id=tracker.sender_id,document=url)

--- a/bot/actions/actions.py
+++ b/bot/actions/actions.py
@@ -12,14 +12,15 @@ class ActionEnviarDocFaqEstagio(Action):
 		bot = telegram.Bot(token='TELEGRAM_TOKEN')
 		url = 'https://fga.unb.br/articles/0002/2354/tce_para_estagio_obrigatorio.pdf'
 		bot.sendDocument(chat_id=tracker.sender_id,document=url)
+		url = 'https://fga.unb.br/articles/0002/2356/tce_para_estagio_nao_obrigatorio.pdf'
+		bot.sendDocument(chat_id=tracker.sender_id,document=url)
 
 class ActionEnviarTCEPA(Action):
 	def name(self):
 		return "action_enviar_tce_pa"
 
 	def run(self, dispatcher, tracker, domain):
-		dispatcher.utter_message("Eu tenho esses documentos de estágio supervisionado!")
-		dispatcher.utter_message("Caso Vossa Majestade queira esses documentos para estágio não-obrigatório, especifique.")
+		dispatcher.utter_message("Eu tenho esses documentos de estágio supervisionado e não-obrigatório!")
 		dispatcher.utter_message("Estou te enviando o TCE e o PA")
 		bot = telegram.Bot(token='TELEGRAM_TOKEN')
 		url = 'https://aprender.ead.unb.br/pluginfile.php/688847/mod_resource/content/5/faq_estagio_supervisionado.pdf'

--- a/bot/actions/actions.py
+++ b/bot/actions/actions.py
@@ -23,8 +23,8 @@ class ActionEnviarTCEPA(Action):
 		bot = telegram.Bot(token='TELEGRAM_TOKEN')
 		url = 'https://fga.unb.br/articles/0002/2354/tce_para_estagio_obrigatorio.pdf'
 		bot.sendDocument(chat_id=tracker.sender_id,document=url)
-		url = 'https://fga.unb.br/articles/0002/2356/tce_para_estagio_nao_obrigatorio.pdf'
-		bot.sendDocument(chat_id=tracker.sender_id,document=url)
+		url2 = 'https://fga.unb.br/articles/0002/2356/tce_para_estagio_nao_obrigatorio.pdf'
+		bot.sendDocument(chat_id=tracker.sender_id,document=url2)
 
 class ActionEnviarFichaSolicitacao(Action):
 	def name(self):

--- a/bot/actions/actions.py
+++ b/bot/actions/actions.py
@@ -3,15 +3,27 @@ import telegram
 from . import webscraping
 
 class ActionEnviarDocFaqEstagio(Action):
-    def name(self):
-        return "action_enviar_doc_faq_estagio"
+	def name(self):
+		return "action_enviar_doc_faq_estagio"
 
-    def run(self, dispatcher, tracker, domain):
-        dispatcher.utter_message("Eu tenho muitas informações sobre estágio para você, Vossa Majestade!")
-        dispatcher.utter_message("Estou te enviando um documento com as dúvidas mais pertinentes que os alunos costumam ter")
-        bot = telegram.Bot(token='TELEGRAM_TOKEN')
-        url = 'https://aprender.ead.unb.br/pluginfile.php/688847/mod_resource/content/5/faq_estagio_supervisionado.pdf'
-        bot.sendDocument(chat_id=tracker.sender_id,document=url)
+	def run(self, dispatcher, tracker, domain):
+		dispatcher.utter_message("Eu tenho muitas informações sobre estágio para você, Vossa Majestade!")
+		dispatcher.utter_message("Estou te enviando um documento com as dúvidas mais pertinentes que os alunos costumam ter")
+		bot = telegram.Bot(token='TELEGRAM_TOKEN')
+		url = 'https://fga.unb.br/articles/0002/2354/tce_para_estagio_obrigatorio.pdf'
+		bot.sendDocument(chat_id=tracker.sender_id,document=url)
+
+class ActionEnviarDocFaqEstagio(Action):
+	def name(self):
+		return "action_enviar_tce_pa"
+
+	def run(self, dispatcher, tracker, domain):
+		dispatcher.utter_message("Eu tenho esses documentos de estágio supervisionado!")
+		dispatcher.utter_message("Caso Vossa Majestade queira esses documentos para estágio não-obrigatório, especifique.")
+		dispatcher.utter_message("Estou te enviando o TCE e o PA")
+		bot = telegram.Bot(token='TELEGRAM_TOKEN')
+		url = 'https://aprender.ead.unb.br/pluginfile.php/688847/mod_resource/content/5/faq_estagio_supervisionado.pdf'
+		bot.sendDocument(chat_id=tracker.sender_id,document=url)
 
 class ActionTodosOsCoordenadores(Action):
 	def name(self):

--- a/coach/data/intents/actions.md
+++ b/coach/data/intents/actions.md
@@ -45,14 +45,6 @@
 - tem o termo rescisório
 - manda o termo rescisório
 
-## intent:action_enviar_relatorio_atividades
-- modelo de relatório de atividades
-- relatório de atividades
-- me envie o relatório de atividades
-- quero o relatório de atividades
-- tem o relatório de atividades
-- manda o relatório de atividades
-
 ## intent:action_enviar_doc_faq_estagio
 - queria saber sobre estagio
 - queria saber sobre estagio supervisionado

--- a/coach/data/intents/actions.md
+++ b/coach/data/intents/actions.md
@@ -1,3 +1,28 @@
+## intent:action_enviar_tce_pa
+- termo de compromisso de estagio
+- tce
+- plano de atividades
+- pa
+- termo de compromisso de estagio e plano de atividades
+- tce e pa
+- me envie o termo de compromisso de estagio
+- me envie o tce
+- quero o termo de compromisso de estagio
+- quero o tce
+- tem o termo de compromisso de estagio
+- tem o tce
+- manda o termo de compromisso de estagio
+- manda o tce
+- me envie o plano de atividades
+- me envie o pa
+- quero o plano de atividades
+- quero o pa
+- tem o plano de atividades
+- tem o pa
+- manda o plano de atividades
+- manda o pa
+
+
 ## intent:action_enviar_doc_faq_estagio
 - queria saber sobre estagio
 - queria saber sobre estagio supervisionado

--- a/coach/data/intents/actions.md
+++ b/coach/data/intents/actions.md
@@ -45,6 +45,14 @@
 - tem o termo rescisório
 - manda o termo rescisório
 
+## intent:action_enviar_relatorio_atividades
+- modelo de relatório de atividades
+- relatório de atividades
+- me envie o relatório de atividades
+- quero o relatório de atividades
+- tem o relatório de atividades
+- manda o relatório de atividades
+
 ## intent:action_enviar_doc_faq_estagio
 - queria saber sobre estagio
 - queria saber sobre estagio supervisionado

--- a/coach/data/intents/actions.md
+++ b/coach/data/intents/actions.md
@@ -37,6 +37,14 @@
 - tem o termo aditivo
 - manda o termo aditivo
 
+## intent:action_enviar_termo_rescisorio
+- modelo de termo rescisório
+- termo rescisório
+- me envie o termo rescisório
+- quero o termo rescisório
+- tem o termo rescisório
+- manda o termo rescisório
+
 ## intent:action_enviar_doc_faq_estagio
 - queria saber sobre estagio
 - queria saber sobre estagio supervisionado

--- a/coach/data/intents/actions.md
+++ b/coach/data/intents/actions.md
@@ -1,17 +1,17 @@
 ## intent:action_enviar_tce_pa
-- termo de compromisso de estagio
+- termo de compromisso de estágio
 - tce
 - plano de atividades
 - pa
-- termo de compromisso de estagio e plano de atividades
+- termo de compromisso de estágio e plano de atividades
 - tce e pa
-- me envie o termo de compromisso de estagio
+- me envie o termo de compromisso de estágio
 - me envie o tce
-- quero o termo de compromisso de estagio
+- quero o termo de compromisso de estágio
 - quero o tce
-- tem o termo de compromisso de estagio
+- tem o termo de compromisso de estágio
 - tem o tce
-- manda o termo de compromisso de estagio
+- manda o termo de compromisso de estágio
 - manda o tce
 - me envie o plano de atividades
 - me envie o pa
@@ -21,6 +21,13 @@
 - tem o pa
 - manda o plano de atividades
 - manda o pa
+
+## intent:action_enviar_ficha_solicitacao
+- ficha de solicitação de matrícula
+- me envie a ficha de solicitação de matrícula
+- quero a ficha de solicitação de matrícula
+- tem a ficha de solicitação de matrícula
+- manda a ficha de solicitação de matrícula
 
 
 ## intent:action_enviar_doc_faq_estagio

--- a/coach/data/intents/actions.md
+++ b/coach/data/intents/actions.md
@@ -29,6 +29,13 @@
 - tem a ficha de solicitação de matrícula
 - manda a ficha de solicitação de matrícula
 
+## intent:action_enviar_modelo_de_termo_aditivo
+- modelo de termo aditivo
+- termo aditivo
+- me envie o termo aditivo
+- quero o termo aditivo
+- tem o termo aditivo
+- manda o termo aditivo
 
 ## intent:action_enviar_doc_faq_estagio
 - queria saber sobre estagio

--- a/coach/data/intents/estagio.md
+++ b/coach/data/intents/estagio.md
@@ -1,3 +1,11 @@
+## intent:enviar_relatorio_atividades
+- modelo de relatório de atividades
+- relatório de atividades
+- me envie o relatório de atividades
+- quero o relatório de atividades
+- tem o relatório de atividades
+- manda o relatório de atividades
+
 ## intent:atividades_estagio
 - quais sao as atividades que podem ser consideradas como estagio supervisionado
 - quais são as atividades que podem ser consideradas como estágio supervisionado

--- a/coach/data/stories/actions.md
+++ b/coach/data/stories/actions.md
@@ -46,18 +46,6 @@
   - action_enviar_termo_rescisorio
   - utter_continuar_conversa
 
-## path_action_enviar_relatorio_atividades 1
-* cumprimentar
-  - utter_cumprimentar
-* action_enviar_relatorio_atividades
-  - action_enviar_relatorio_atividades
-  - utter_continuar_conversa
-
-## path_action_enviar_relatorio_atividades 2
-* action_enviar_relatorio_atividades
-  - action_enviar_relatorio_atividades
-  - utter_continuar_conversa
-
 ## path_action_enviar_doc_faq_estagio 1
 * cumprimentar
   - utter_cumprimentar

--- a/coach/data/stories/actions.md
+++ b/coach/data/stories/actions.md
@@ -34,6 +34,18 @@
   - action_enviar_modelo_de_termo_aditivo
   - utter_continuar_conversa
 
+## path_action_enviar_termo_rescisorio 1
+* cumprimentar
+  - utter_cumprimentar
+* action_enviar_termo_rescisorio
+  - action_enviar_termo_rescisorio
+  - utter_continuar_conversa
+
+## path_action_enviar_termo_rescisorio 2
+* action_enviar_termo_rescisorio
+  - action_enviar_termo_rescisorio
+  - utter_continuar_conversa
+
 ## path_action_enviar_doc_faq_estagio 1
 * cumprimentar
   - utter_cumprimentar

--- a/coach/data/stories/actions.md
+++ b/coach/data/stories/actions.md
@@ -46,6 +46,18 @@
   - action_enviar_termo_rescisorio
   - utter_continuar_conversa
 
+## path_action_enviar_relatorio_atividades 1
+* cumprimentar
+  - utter_cumprimentar
+* action_enviar_relatorio_atividades
+  - action_enviar_relatorio_atividades
+  - utter_continuar_conversa
+
+## path_action_enviar_relatorio_atividades 2
+* action_enviar_relatorio_atividades
+  - action_enviar_relatorio_atividades
+  - utter_continuar_conversa
+
 ## path_action_enviar_doc_faq_estagio 1
 * cumprimentar
   - utter_cumprimentar

--- a/coach/data/stories/actions.md
+++ b/coach/data/stories/actions.md
@@ -1,3 +1,15 @@
+## path_action_enviar_tce_pa 1
+* cumprimentar
+  - utter_cumprimentar
+* action_enviar_tce_pa
+  - action_enviar_tce_pa
+  - utter_continuar_conversa
+
+## path_action_enviar_tce_pa 2
+* action_enviar_tce_pa
+  - action_enviar_tce_pa
+  - utter_continuar_conversa
+
 ## path_action_enviar_doc_faq_estagio 1
 * cumprimentar
   - utter_cumprimentar

--- a/coach/data/stories/actions.md
+++ b/coach/data/stories/actions.md
@@ -22,6 +22,18 @@
   - action_enviar_ficha_solicitacao
   - utter_continuar_conversa
 
+## path_action_enviar_modelo_de_termo_aditivo 1
+* cumprimentar
+  - utter_cumprimentar
+* action_enviar_modelo_de_termo_aditivo
+  - action_enviar_modelo_de_termo_aditivo
+  - utter_continuar_conversa
+
+## path_action_enviar_modelo_de_termo_aditivo 2
+* action_enviar_modelo_de_termo_aditivo
+  - action_enviar_modelo_de_termo_aditivo
+  - utter_continuar_conversa
+
 ## path_action_enviar_doc_faq_estagio 1
 * cumprimentar
   - utter_cumprimentar

--- a/coach/data/stories/actions.md
+++ b/coach/data/stories/actions.md
@@ -10,6 +10,18 @@
   - action_enviar_tce_pa
   - utter_continuar_conversa
 
+## path_action_enviar_ficha_solicitacao 1
+* cumprimentar
+  - utter_cumprimentar
+* action_enviar_ficha_solicitacao
+  - action_enviar_ficha_solicitacao
+  - utter_continuar_conversa
+
+## path_action_enviar_ficha_solicitacao 2
+* action_enviar_ficha_solicitacao
+  - action_enviar_ficha_solicitacao
+  - utter_continuar_conversa
+
 ## path_action_enviar_doc_faq_estagio 1
 * cumprimentar
   - utter_cumprimentar

--- a/coach/data/stories/estagio.md
+++ b/coach/data/stories/estagio.md
@@ -1,3 +1,15 @@
+## path_enviar_relatorio_atividades 1
+* cumprimentar
+  - utter_cumprimentar
+* action_enviar_relatorio_atividades
+  - action_enviar_relatorio_atividades
+  - utter_continuar_conversa
+
+## path_enviar_relatorio_atividades 2
+* action_enviar_relatorio_atividades
+  - action_enviar_relatorio_atividades
+  - utter_continuar_conversa
+
 <!-- Testado -->
 ## path_atividades_estagio 1
 * cumprimentar

--- a/coach/domain.yml
+++ b/coach/domain.yml
@@ -68,6 +68,7 @@ intents:
   - action_coordenador_de_energia
   - action_coordenador_de_software
   - action_todos_os_coordenadores
+  - action_enviar_ficha_solicitacao
 
 entities:
   - religiao
@@ -696,3 +697,4 @@ actions:
   - action_coordenador_de_software
   - action_todos_os_coordenadores
   - action_enviar_tce_pa
+  - action_enviar_ficha_solicitacao

--- a/coach/domain.yml
+++ b/coach/domain.yml
@@ -60,6 +60,7 @@ intents:
   - como_pedido_reintegracao
   - revisar_mencao
 
+  - action_enviar_tce_pa
   - action_enviar_doc_faq_estagio
   - action_coordenador_de_automotiva
   - action_coordenador_de_eletronica
@@ -694,3 +695,4 @@ actions:
   - action_coordenador_de_energia
   - action_coordenador_de_software
   - action_todos_os_coordenadores
+  - action_enviar_tce_pa

--- a/coach/domain.yml
+++ b/coach/domain.yml
@@ -71,6 +71,7 @@ intents:
   - action_enviar_ficha_solicitacao
   - action_enviar_modelo_de_termo_aditivo
   - action_enviar_termo_rescisorio
+  - action_enviar_relatorio_atividades
 
 entities:
   - religiao
@@ -702,3 +703,4 @@ actions:
   - action_enviar_ficha_solicitacao
   - action_enviar_modelo_de_termo_aditivo
   - action_enviar_termo_rescisorio
+  - action_enviar_relatorio_atividades

--- a/coach/domain.yml
+++ b/coach/domain.yml
@@ -59,6 +59,7 @@ intents:
   - quando_pedido_reintegracao
   - como_pedido_reintegracao
   - revisar_mencao
+  - enviar_relatorio_atividades
 
   - action_enviar_tce_pa
   - action_enviar_doc_faq_estagio
@@ -71,7 +72,7 @@ intents:
   - action_enviar_ficha_solicitacao
   - action_enviar_modelo_de_termo_aditivo
   - action_enviar_termo_rescisorio
-  - action_enviar_relatorio_atividades
+  
 
 entities:
   - religiao
@@ -630,6 +631,11 @@ templates:
         Vossa Majestade deve ir na secretaria e pedir o documento referente a isso, nesse documento vai perguntar, o motivo da solicitação, o nome e o código da disciplina, sua turma e qual era o professor, por quê sua menção deve ser revisada e etc.
         Depois de preencher os dados basta entregar na secretaria e esperar os resultados, normalmente ele chega no e-mail.
         Boa sorte, faraó!
+  utter_enviar_relatorio_atividades:
+  - text: |
+        Eu tenho um modelo de relatório de atividades. Aqui está um link para baixá-lo no formato de planilha:
+
+        https://fga.unb.br/estagio/documentos/documentos-do-daia/relatorio-de-atividades-de-estagio.xlsx
 
 actions:
   - utter_start
@@ -691,6 +697,7 @@ actions:
   - utter_quando_pedido_reintegracao
   - utter_como_pedido_reintegracao
   - utter_revisar_mencao
+  - utter_enviar_relatorio_atividades
 
   - action_enviar_doc_faq_estagio
   - action_coordenador_de_automotiva
@@ -703,4 +710,3 @@ actions:
   - action_enviar_ficha_solicitacao
   - action_enviar_modelo_de_termo_aditivo
   - action_enviar_termo_rescisorio
-  - action_enviar_relatorio_atividades

--- a/coach/domain.yml
+++ b/coach/domain.yml
@@ -69,6 +69,7 @@ intents:
   - action_coordenador_de_software
   - action_todos_os_coordenadores
   - action_enviar_ficha_solicitacao
+  - action_enviar_modelo_de_termo_aditivo
 
 entities:
   - religiao
@@ -698,3 +699,4 @@ actions:
   - action_todos_os_coordenadores
   - action_enviar_tce_pa
   - action_enviar_ficha_solicitacao
+  - action_enviar_modelo_de_termo_aditivo

--- a/coach/domain.yml
+++ b/coach/domain.yml
@@ -70,6 +70,7 @@ intents:
   - action_todos_os_coordenadores
   - action_enviar_ficha_solicitacao
   - action_enviar_modelo_de_termo_aditivo
+  - action_enviar_termo_rescisorio
 
 entities:
   - religiao
@@ -700,3 +701,4 @@ actions:
   - action_enviar_tce_pa
   - action_enviar_ficha_solicitacao
   - action_enviar_modelo_de_termo_aditivo
+  - action_enviar_termo_rescisorio


### PR DESCRIPTION
## #61 Adicionando documentos de estágio que o bot envia

## Descrição

Adiciona actions de envio dos seguintes documentos relativos ao estágio:
- Termo de Compromisso de Estágio;
- Plano de Atividades;
- Ficha de Solicitação de Matrícula;
- Modelo de Termo Aditivo;
- Modelo de Termo Rescisório.

Adiciona utter de envio do link do seguinte documento relativo ao estágio:
- Modelo de Relatóriod e Atividades

## Resolve (Issues)

Closes #61

## Tarefas
* Aumenta a gama de documentação.
* Certifica que o bot envie a documentação atualizada e correta.


