### PR TITLE
#89 Editando o /start com os novos assuntos adicionados ao bot.

### DIFF
--- a/coach/domain.yml
+++ b/coach/domain.yml
@@ -111,17 +111,9 @@ templates:
   utter_start:
     - text: |
         Oi eu sou o Nilo!
-        Posso te ajudar a tirar suas dúvidas sobre estágio, e assuntos academicos como:
-        1. Qual o objetivo do estagio.
-        2. Quais sao as atividades que podem ser consideradas como estagio.
-        3. Quais sao os pre-requisitos do estágio.
-        4. Como funciona a matricula no estagio.
-        5. Link para o moodle do estagio.
-        6. Quais os documentos necessarios para o estagio.
-        7. Atendimento coordenadores de estágio.
-        8. Quando um estudante entra em risco de desligamento.
-        9. Como fazer o pedido de reintegracao.
+        Posso te ajudar a tirar suas dúvidas sobre estágio e muitos assuntos que os alunos da UNB precisam procurar na Coordenação e na Secretaria, como desligamento, reintegração, dupla diplomação, entre outros.
 
+        Faça a sua pergunta e tentarei lhe ajudar! Caso tenha dificuldades em fazer uma pergunta, digite "/help" para ver o menu de ajuda.
   utter_help:
     - text: |
 


### PR DESCRIPTION
Signed-off-by: gabriel-paiva <gabrielpaivaaguiar.gp@gmail.com>
## Descrição

A intent /start do projeto ainda estava referenciando os conhecimentos do bot na Release 1. Essa intent foi atualizada com os novos assuntos que o bot pode tratar e também referencia a "/help", caso ainda restem dúvidas ao usuário.

## Resolve (Issues)

* Closes #89 

## Tarefas (Tasks)

- [] Referenciar os assuntos conhecidos pelo bot: Para melhorar a experiência do usuário, não citei todos os assuntos que o bot conhece, para não gerar um texto enorme desnecessariamente. A referência ao /help já preenche essa lacuna, caso o usuário queira ver tudo o que o bot sabe.
- [] Referenciar o /help.

