### PR TITLE
Fix #92 Altera o nome das imagens do bot para evitar conflitos.

### DIFF
--- a/docker/actions.Dockerfile
+++ b/docker/actions.Dockerfile
@@ -1,4 +1,4 @@
-FROM lappis/botrequirements:boilerplate
+FROM yukioz/requirements
 
 ADD ./bot/actions/actions.py /bot/actions/actions.py
 ADD ./bot/Makefile /bot/Makefile

--- a/docker/coach.Dockerfile
+++ b/docker/coach.Dockerfile
@@ -1,4 +1,4 @@
-FROM lappis/botrequirements:boilerplate
+FROM yukioz/requirements
 
 COPY ./coach /coach
 COPY ./scripts /scripts

--- a/docker/notebooks.Dockerfile
+++ b/docker/notebooks.Dockerfile
@@ -1,4 +1,4 @@
-FROM lappis/botrequirements:boilerplate
+FROM yukioz/requirements
 
 RUN apt-get install -y graphviz libgraphviz-dev pkg-config
 


### PR DESCRIPTION
## Descrição

Foram alteradas os nomes das imagens que estavam nos arquivos Dockerfile, de "lappis/botrequirements:boilerplate" para "yukioz/requirements".

## Resolve (Issues)

Issues que foram resolvidas:

* Closes #92 .

## Tarefas

* Alterar o nome das imagens
* Evitar conflitos no build das imagens