### PR TITLE
Fix #93 Alterando o nome da tag do build para "yukioz/requirements."

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
 
   # ================================= Bot =====================================
   bot:
-    image: yukioz/requirements
+    image: yukioz/bot
     container_name: bot_rocketchat
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
 
   # ================================= Bot =====================================
   bot:
-    image: lappis/bot:boilerplate
+    image: yukioz/requirements
     container_name: bot_rocketchat
     build:
       context: .


### PR DESCRIPTION
## Descrição

Foi realizada a alteração da tag do nome da imagem gerada ao final do treinamento do bot, que antes era "lappis/bot:boillerplate" para "yukioz/requirements".

## Resolve (Issues)
 
Corrige o seguinte Pull Request:

## Pull_Requests relacionados

branch | Pull-request
------ | ------
Fix/image_bot | #93  
