### PR TITLE
Fix #95 Consertando a action para enviar o doc de faq_estagio

### DIFF
--- a/bot/actions/actions.py
+++ b/bot/actions/actions.py
@@ -8,14 +8,14 @@ class ActionEnviarDocFaqEstagio(Action):
         return "action_enviar_doc_faq_estagio"
 
     def run(self, dispatcher, tracker, domain):
-        dispatcher.utter_message("Eu tenho muitas informações sobre estágio \
-                                 para você, Vossa Majestade!")
-        dispatcher.utter_message("Estou te enviando um documento com as \
-                                 dúvidas mais pertinentes que os alunos \
-                                 costumam ter")
+        dispatcher.utter_message("Eu tenho muitas informações sobre estágio " +
+                                 "para você, Vossa Majestade!")
+        dispatcher.utter_message("Estou te enviando um documento com as " +
+                                 "dúvidas mais pertinentes que os alunos " +
+                                 "costumam ter")
         bot = telegram.Bot(token='TELEGRAM_TOKEN')
-        url = ('https://aprender.ead.unb.br/pluginfile.php/688847/' +
-               'mod_resource/content/5/faq_estagio_supervisionado.pdf')
+        url = 'https://www.docdroid.net/file/download/RdSYmiN'
+        url += '/faq-estagio-supervisionado.pdf'
         bot.sendDocument(chat_id=tracker.sender_id, document=url)
 
 


### PR DESCRIPTION
## Descrição

O antigo link do documento de faq_estágio tinha se tornado um link privado disponível apenas para alunos matriculados na matéria estágio supervisionado no moodle, portanto, o bot não tinha acesso a esse documento para enviá-lo via action. Para corrigir isso, foi feito o upload desse documento através do docdroid.net e foi trocado o link antigo pelo link de download no docdroid.

## Resolve (Issues)

Issues que foram resolvidas:

* Closes #95 